### PR TITLE
Fix index.d.ts not export some declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare class Recipe {
+export declare class Recipe {
     constructor(recipeEnumItem: object);
 
     result: RecipeItem;
@@ -10,7 +10,7 @@ declare class Recipe {
 
     static find(itemType: number, metadata: number | null): Array<Recipe>;
 }
-declare class RecipeItem {
+export declare class RecipeItem {
     constructor(id: number, metadata: number | null, count: number);
 
     id: number;


### PR DESCRIPTION
Recipe and RecipeItem are not exported as types in index.d.ts making them not importable from other modules