### PR TITLE
fix: incorrect metadata and incorrect count updates

### DIFF
--- a/lib/recipe.js
+++ b/lib/recipe.js
@@ -60,7 +60,7 @@ function computeDelta (recipe) {
   if (recipe.outShape) applyShape(recipe.outShape, 1)
   if (recipe.ingredients) applyIngredients(recipe.ingredients)
   // add the result
-  add(recipe.result)
+  add(RecipeItem.clone(recipe.result))
   return delta
 
   // add to delta
@@ -92,7 +92,7 @@ function computeDelta (recipe) {
   function applyIngredients (ingredients) {
     let i
     for (i = 0; i < ingredients.length; ++i) {
-      add(ingredients[i])
+      add(RecipeItem.clone(ingredients[i]))
     }
   }
 }

--- a/lib/recipe_item.js
+++ b/lib/recipe_item.js
@@ -14,7 +14,7 @@ RecipeItem.fromEnum = function (itemFromRecipeEnum) {
       case 'number':
         return new RecipeItem(itemFromRecipeEnum, null, 1)
       case 'object':
-        return new RecipeItem(itemFromRecipeEnum.id, itemFromRecipeEnum.metadata == null ? itemFromRecipeEnum.metadata : null, itemFromRecipeEnum.count || 1)
+        return new RecipeItem(itemFromRecipeEnum.id, itemFromRecipeEnum.metadata == null ? null : itemFromRecipeEnum.metadata, itemFromRecipeEnum.count || 1)
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "typings": "index.d.ts",
   "scripts": {
-    "test": "npm run lint",
+    "test": "mocha test/ && npm run lint",
     "lint": "standard",
     "fix": "standard --fix"
   },
@@ -17,6 +17,7 @@
     "prismarine-registry": "^1.4.0"
   },
   "devDependencies": {
+    "mocha": "^10.2.0",
     "standard": "^17.0.0"
   },
   "keywords": [

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,0 +1,113 @@
+/* eslint-env mocha */
+const assert = require('assert')
+const RecipeItem = require('../lib/recipe_item')
+const recipeLoader = require('../lib/recipe')
+
+describe('RecipeItem', function () {
+  describe('fromEnum', function () {
+    it('should set metadata to null when metadata is not present', function () {
+      const item = RecipeItem.fromEnum({ id: 1 })
+      assert.strictEqual(item.id, 1)
+      assert.strictEqual(item.metadata, null)
+      assert.strictEqual(item.count, 1)
+    })
+
+    it('should preserve metadata value when metadata is present', function () {
+      const item = RecipeItem.fromEnum({ id: 1, metadata: 3 })
+      assert.strictEqual(item.id, 1)
+      assert.strictEqual(item.metadata, 3)
+      assert.strictEqual(item.count, 1)
+    })
+
+    it('should preserve metadata value of 0', function () {
+      const item = RecipeItem.fromEnum({ id: 1, metadata: 0 })
+      assert.strictEqual(item.id, 1)
+      assert.strictEqual(item.metadata, 0)
+      assert.strictEqual(item.count, 1)
+    })
+
+    it('should handle number input', function () {
+      const item = RecipeItem.fromEnum(5)
+      assert.strictEqual(item.id, 5)
+      assert.strictEqual(item.metadata, null)
+      assert.strictEqual(item.count, 1)
+    })
+
+    it('should handle null input', function () {
+      const item = RecipeItem.fromEnum(null)
+      assert.strictEqual(item.id, -1)
+      assert.strictEqual(item.metadata, null)
+      assert.strictEqual(item.count, 1)
+    })
+
+    it('should use count from object when provided', function () {
+      const item = RecipeItem.fromEnum({ id: 1, metadata: 2, count: 4 })
+      assert.strictEqual(item.count, 4)
+    })
+  })
+})
+
+describe('Recipe', function () {
+  describe('computeDelta mutation', function () {
+    it('should not mutate ingredient counts after recipe creation', function () {
+      const registry = {
+        recipes: {
+          1: [{
+            result: { id: 1, count: 1 },
+            ingredients: [2, 3]
+          }]
+        }
+      }
+      const Recipe = recipeLoader(registry)
+      const recipe = Recipe.find(1)[0]
+
+      // Ingredients should have count of -1 (consumed)
+      assert.strictEqual(recipe.ingredients[0].count, -1)
+      assert.strictEqual(recipe.ingredients[1].count, -1)
+
+      // The delta should also reflect -1 for ingredients
+      const ingredientDeltas = recipe.delta.filter(d => d.id === 2 || d.id === 3)
+      for (const d of ingredientDeltas) {
+        assert.strictEqual(d.count, -1)
+      }
+    })
+
+    it('should not mutate result count after recipe creation', function () {
+      const registry = {
+        recipes: {
+          1: [{
+            result: { id: 1, count: 2 },
+            ingredients: [2]
+          }]
+        }
+      }
+      const Recipe = recipeLoader(registry)
+      const recipe = Recipe.find(1)[0]
+
+      // Result count should remain as originally set
+      assert.strictEqual(recipe.result.count, 2)
+
+      // Delta for the result should also be 2 (produced)
+      const resultDelta = recipe.delta.find(d => d.id === 1)
+      assert.strictEqual(resultDelta.count, 2)
+    })
+
+    it('should not mutate inShape items after recipe creation', function () {
+      const registry = {
+        recipes: {
+          4: [{
+            result: { id: 4, count: 1 },
+            inShape: [[1, 2], [3, null]]
+          }]
+        }
+      }
+      const Recipe = recipeLoader(registry)
+      const recipe = Recipe.find(4)[0]
+
+      // inShape items should not have their counts modified by computeDelta
+      assert.strictEqual(recipe.inShape[0][0].count, 1)
+      assert.strictEqual(recipe.inShape[0][1].count, 1)
+      assert.strictEqual(recipe.inShape[1][0].count, 1)
+    })
+  })
+})


### PR DESCRIPTION
## recipe_item.js

Code used to have
```js
itemFromRecipeEnum.metadata == null ? itemFromRecipeEnum.metadata : null
```
which makes zero sense. Switched around to address instances where `.metadata === null` and `.metadata === undefined`.

This could cause subsequent `itemA.metadata === itemB.metadata` to be false when one was `null` and the other was `undefined`.

### Example of incorrect behavoir:

When calculating deltas for items that produce themselves, such as netherite upgrade smithing templates, incorrect metadata would cause the result to not combine with the ingredients.

Without fix:
```js
  delta: [
    RecipeItem { id: 805, metadata: null, count: -7 },
    RecipeItem { id: 1269, metadata: null, count: -1 }, // should be merged
    RecipeItem { id: 325, metadata: null, count: -1 },
    RecipeItem { id: 1269, metadata: undefined, count: 2 } // should be merged
  ],
```

With fix:
```js
  delta: [
    RecipeItem { id: 805, metadata: null, count: -7 },
    RecipeItem { id: 1269, metadata: null, count: 1 }, // correctly merged
    RecipeItem { id: 325, metadata: null, count: -1 }
  ],
```

## recipe.js

Updated `computeDelta` function to also clone ingredient recipes and result. The problem was, for recipes that use `.ingredients` (shapeless recipes), the previous delta counter was updating the same `RecipeItem` object that was stored in the `.ingredients`. This was causing the `.count` to be incorrect.

### Example of incorrect behavior below using the following script:

```js
const registry = require("prismarine-registry")("1.21.1");
const Recipe = require("prismarine-recipe")(registry).Recipe;

const itemId = registry.itemsByName.red_concrete_powder.id;
const itemRecipe = Recipe.find(itemId)[0];

function showRecipe(recipe) {
    console.log(
        recipe.ingredients.map((ingredient) => {
            return {
                name: registry.items[ingredient.id]?.name,
                count: ingredient.count,
            };
        })
    );
}

showRecipe(itemRecipe);
```

Without fix:
```js
[
  { name: 'red_dye', count: -1 },
  { name: 'sand', count: -4 }, // should be -1
  { name: 'sand', count: -1 },
  { name: 'sand', count: -1 },
  { name: 'sand', count: -1 },
  { name: 'gravel', count: -4 }, // should be -1
  { name: 'gravel', count: -1 },
  { name: 'gravel', count: -1 },
  { name: 'gravel', count: -1 }
]
```

With fix:
```js
[
  { name: 'red_dye', count: -1 },
  { name: 'sand', count: -1 }, // correct
  { name: 'sand', count: -1 },
  { name: 'sand', count: -1 },
  { name: 'sand', count: -1 },
  { name: 'gravel', count: -1 }, // correct
  { name: 'gravel', count: -1 },
  { name: 'gravel', count: -1 },
  { name: 'gravel', count: -1 }
]
```
