### PR TITLE
Fix wildcard metadata for pre-1.13 recipe ingredients

### DIFF
--- a/lib/recipe.js
+++ b/lib/recipe.js
@@ -1,10 +1,12 @@
 let recipes
+let items
 const RecipeItem = require('./recipe_item')
 
 module.exports = loader
 
 function loader (registry) {
   recipes = registry.recipes
+  items = registry.items || {}
   return Recipe
 }
 
@@ -97,13 +99,34 @@ function computeDelta (recipe) {
   }
 }
 
+function normalizeMetadata (recipeItem) {
+  if (recipeItem.metadata == null || recipeItem.id === -1) return recipeItem
+  // Vanilla Minecraft uses 32767 as the wildcard damage value in recipes
+  if (recipeItem.metadata >= 32767) {
+    recipeItem.metadata = null
+    return recipeItem
+  }
+  // If the item has known variations and the metadata doesn't match any of them,
+  // treat it as a wildcard. This handles cases like minecraft-data using block
+  // metadata (e.g. 12 for all-bark log) in recipes, which doesn't correspond
+  // to any valid item variant (logs as items only have metadata 0-5).
+  const itemData = items[recipeItem.id]
+  if (itemData && itemData.variations) {
+    const validMetadata = itemData.variations.map(function (v) { return v.metadata })
+    if (validMetadata.indexOf(recipeItem.metadata) === -1) {
+      recipeItem.metadata = null
+    }
+  }
+  return recipeItem
+}
+
 function reformatShape (shape) {
   const out = new Array(shape.length)
   let x, y, row, outRow
   for (y = 0; y < shape.length; ++y) {
     row = shape[y]
     out[y] = outRow = new Array(row.length)
-    for (x = 0; x < outRow.length; ++x) { outRow[x] = RecipeItem.fromEnum(row[x]) }
+    for (x = 0; x < outRow.length; ++x) { outRow[x] = normalizeMetadata(RecipeItem.fromEnum(row[x])) }
   }
   return out
 }
@@ -111,7 +134,7 @@ function reformatShape (shape) {
 function reformatIngredients (ingredients) {
   const out = new Array(ingredients.length)
   for (let i = 0; i < out.length; ++i) {
-    const item = RecipeItem.fromEnum(ingredients[i])
+    const item = normalizeMetadata(RecipeItem.fromEnum(ingredients[i]))
     item.count = -1
     out[i] = item
   }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -110,4 +110,125 @@ describe('Recipe', function () {
       assert.strictEqual(recipe.inShape[1][0].count, 1)
     })
   })
+
+  describe('wildcard metadata normalization', function () {
+    it('should treat metadata >= 32767 as wildcard (null)', function () {
+      const registry = {
+        items: {},
+        recipes: {
+          1: [{
+            result: { id: 1, count: 1 },
+            inShape: [[{ id: 17, metadata: 32767 }]]
+          }]
+        }
+      }
+      const Recipe = recipeLoader(registry)
+      const recipe = Recipe.find(1)[0]
+
+      assert.strictEqual(recipe.inShape[0][0].metadata, null)
+      const ingredientDelta = recipe.delta.find(d => d.id === 17)
+      assert.strictEqual(ingredientDelta.metadata, null)
+    })
+
+    it('should treat metadata as wildcard when it does not match any item variation', function () {
+      const registry = {
+        items: {
+          17: {
+            id: 17,
+            name: 'log',
+            variations: [
+              { metadata: 0, displayName: 'Oak Wood' },
+              { metadata: 1, displayName: 'Spruce Wood' },
+              { metadata: 2, displayName: 'Birch Wood' },
+              { metadata: 3, displayName: 'Jungle Wood' }
+            ]
+          }
+        },
+        recipes: {
+          5: [{
+            result: { id: 5, count: 4, metadata: 0 },
+            inShape: [[{ id: 17, metadata: 12 }]]
+          }]
+        }
+      }
+      const Recipe = recipeLoader(registry)
+      const recipe = Recipe.find(5)[0]
+
+      // metadata 12 is not a valid item variation for log, so it should be null
+      assert.strictEqual(recipe.inShape[0][0].metadata, null)
+      const logDelta = recipe.delta.find(d => d.id === 17)
+      assert.strictEqual(logDelta.metadata, null)
+    })
+
+    it('should preserve metadata when it matches a valid item variation', function () {
+      const registry = {
+        items: {
+          35: {
+            id: 35,
+            name: 'wool',
+            variations: [
+              { metadata: 0, displayName: 'White Wool' },
+              { metadata: 1, displayName: 'Orange Wool' },
+              { metadata: 2, displayName: 'Magenta Wool' }
+            ]
+          }
+        },
+        recipes: {
+          1: [{
+            result: { id: 1, count: 1 },
+            inShape: [[{ id: 35, metadata: 1 }]]
+          }]
+        }
+      }
+      const Recipe = recipeLoader(registry)
+      const recipe = Recipe.find(1)[0]
+
+      // metadata 1 is a valid variation for wool, so it should be preserved
+      assert.strictEqual(recipe.inShape[0][0].metadata, 1)
+    })
+
+    it('should normalize metadata in ingredients too', function () {
+      const registry = {
+        items: {
+          17: {
+            id: 17,
+            name: 'log',
+            variations: [
+              { metadata: 0, displayName: 'Oak Wood' },
+              { metadata: 1, displayName: 'Spruce Wood' }
+            ]
+          }
+        },
+        recipes: {
+          5: [{
+            result: { id: 5, count: 4 },
+            ingredients: [{ id: 17, metadata: 12 }]
+          }]
+        }
+      }
+      const Recipe = recipeLoader(registry)
+      const recipe = Recipe.find(5)[0]
+
+      assert.strictEqual(recipe.ingredients[0].metadata, null)
+    })
+
+    it('should preserve metadata when item has no variations', function () {
+      const registry = {
+        items: {
+          10: { id: 10, name: 'something' }
+        },
+        recipes: {
+          1: [{
+            result: { id: 1, count: 1 },
+            inShape: [[{ id: 10, metadata: 5 }]]
+          }]
+        }
+      }
+      const Recipe = recipeLoader(registry)
+      const recipe = Recipe.find(1)[0]
+
+      // No variations data, so metadata should be preserved as-is
+      assert.strictEqual(recipe.inShape[0][0].metadata, 5)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Normalizes recipe ingredient metadata to `null` (wildcard) when the metadata value >= 32767 (vanilla wildcard) or when it doesn't match any known item variation in the registry
- Fixes pre-1.13 recipes where minecraft-data uses block metadata values (e.g. 12-15 for all-bark log variants) that don't correspond to valid item metadata (e.g. 0-5 for log items), causing inventory count checks to fail
- Preserves metadata for ingredients where the value matches a valid item variation (e.g. colored wool recipes)

## Details
In minecraft-data for 1.8, the planks recipe specifies log (id 17) with metadata 12-15 (block-level "all bark" variants). However, log items in inventory only have metadata 0-5. When `computeDelta` propagates metadata 12 into the delta, downstream consumers like mineflayer's `requirementsMetForRecipe` call `inventory.count(17, 12)` which returns 0 even when the player has oak logs (metadata 0).

The fix adds a `normalizeMetadata` function in `recipe.js` that:
1. Converts metadata >= 32767 to null (standard vanilla wildcard)
2. Checks the registry's item variations - if the metadata doesn't match any known variation, it's set to null

This is applied during `reformatShape` and `reformatIngredients` so both `inShape`/`ingredients` and `delta` reflect the corrected values.

## Test plan
- [x] Added test: metadata >= 32767 is treated as wildcard
- [x] Added test: metadata not matching any item variation is treated as wildcard (the log case)
- [x] Added test: valid metadata is preserved (colored wool case)
- [x] Added test: metadata normalized in ingredients (not just inShape)
- [x] Added test: metadata preserved when item has no variations data
- [x] All existing tests still pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)