### PR TITLE
Overhaul: Complete support for both Java and Bedrock editions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ const Recipe=require("prismarine-recipe")("1.8").Recipe;
 console.log(JSON.stringify(Recipe.find(5)[0],null,2)); // recipes for wood
 ```
 
+Bedrock recipe data can also be queried by item name:
+
+```js
+const Recipe=require("prismarine-recipe")("bedrock_1.21.80").Recipe;
+
+console.log(JSON.stringify(Recipe.find("cake")[0],null,2));
+```
+
 ## API
 
 ### Recipe
@@ -20,17 +28,50 @@ console.log(JSON.stringify(Recipe.find(5)[0],null,2)); // recipes for wood
 
 Returns a list of matching `Recipe` instances.
 
- * `itemType` - numerical id
+ * `itemType` - numerical id, or an item name for registries with named items
  * `metadata` - metadata to match. `null` means match anything.
 
 #### recipe.result
 
-The output item. It's a recipeItem :
+The primary output item. It's a recipeItem :
 ```js
 {
   id:45,
   metadata:3,
   count:1
+}
+```
+
+#### recipe.edition
+
+Either `java` or `bedrock`. This is the discriminant for the version-agnostic recipe format and can be used to narrow the TypeScript `Recipe` union.
+
+#### recipe.results
+
+All output items. This includes secondary outputs in Bedrock recipes, such as empty buckets returned by the cake recipe.
+
+#### recipe.type
+
+The recipe station/type when the registry exposes one, for example `crafting_table`, `stonecutter`, or `furnace`.
+
+#### recipe.name
+
+The recipe identifier when the registry exposes one.
+
+## TypeScript
+
+The package exposes a version-agnostic `Recipe` union, plus `JavaRecipe` and `BedrockRecipe` for edition-specific usage. Literal version strings infer the specific recipe type:
+
+```ts
+import recipeLoader, { BedrockRecipe, JavaRecipe, Recipe } from 'prismarine-recipe'
+
+const javaRecipe: JavaRecipe = recipeLoader('1.21.4').Recipe.find(5)[0]
+const bedrockRecipe: BedrockRecipe = recipeLoader('bedrock_1.21.80').Recipe.find('cake')[0]
+
+function handleRecipe (recipe: Recipe) {
+  if (recipe.edition === 'bedrock') {
+    console.log(recipe.type)
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ const Recipe=require("prismarine-recipe")("1.8").Recipe;
 console.log(JSON.stringify(Recipe.find(5)[0],null,2)); // recipes for wood
 ```
 
-Bedrock recipe data can also be queried by item name:
+You can also pass an existing `prismarine-registry` instance:
+
+```js
+const registry=require("prismarine-registry")("1.21.4");
+const Recipe=require("prismarine-recipe")(registry).Recipe;
+```
+
+Bedrock recipe data can be queried by item name or numeric id:
 
 ```js
 const Recipe=require("prismarine-recipe")("bedrock_1.21.80").Recipe;
@@ -28,8 +35,10 @@ console.log(JSON.stringify(Recipe.find("cake")[0],null,2));
 
 Returns a list of matching `Recipe` instances.
 
- * `itemType` - numerical id, or an item name for registries with named items
+ * `itemType` - numerical id, or an item name for Bedrock/named registries
  * `metadata` - metadata to match. `null` means match anything.
+
+The returned recipe uses the same normalized shape for Java and Bedrock. Existing Java fields are preserved, with additional fields for edition-aware code.
 
 #### recipe.result
 
@@ -48,15 +57,55 @@ Either `java` or `bedrock`. This is the discriminant for the version-agnostic re
 
 #### recipe.results
 
-All output items. This includes secondary outputs in Bedrock recipes, such as empty buckets returned by the cake recipe.
+All output items. For Java this is usually the same item as `recipe.result`. For Bedrock this includes secondary outputs, such as empty buckets returned by the cake recipe.
 
 #### recipe.type
 
-The recipe station/type when the registry exposes one, for example `crafting_table`, `stonecutter`, or `furnace`.
+The recipe station/type when the registry exposes one, for example `crafting_table`, `stonecutter`, or `furnace`. This value comes from registry data and should be treated as an open string.
 
 #### recipe.name
 
 The recipe identifier when the registry exposes one.
+
+#### recipe.inShape
+
+Looks like this:
+
+```js
+[
+  [recipeItem, recipeItem],
+  [recipeItem, recipeItem],
+  [recipeItem, recipeItem],
+]
+```
+
+#### recipe.outShape
+
+Looks the same as `inShape`. Only present when the registry exposes shaped output slots.
+
+#### recipe.ingredients
+
+List of shape-independent ingredients. Looks like this:
+
+```js
+[
+  recipeItem,
+  recipeItem
+]
+```
+
+### RecipeItem
+
+A recipe item has the following fields:
+
+```js
+{
+  id:45,
+  metadata:3,
+  count:1,
+  name:"bricks" // present when the registry item was name-based
+}
+```
 
 ## TypeScript
 
@@ -75,32 +124,7 @@ function handleRecipe (recipe: Recipe) {
 }
 ```
 
-#### recipe.inShape
-
-Looks like this:
-
-```js
-[
-  [recipeItem, recipeItem],
-  [recipeItem, recipeItem],
-  [recipeItem, recipeItem],
-]
-```
-
-#### recipe.outShape
-
-Looks the same as `inShape`. Only relevant for cake.
-
-#### recipe.ingredients
-
-List of shape-independent ingredients. Looks like this:
-
-```js
-[
-  recipeItem,
-  recipeItem
-]
-```
+The exported types reuse `minecraft-data` registry/item types where possible, and include Bedrock-specific recipe input/output types for the newer Bedrock recipe format.
 
 #### recipe.requiresTable
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import type MinecraftData = require('minecraft-data')
+import type MinecraftData = require('prismarine-registry')
 
 export type MinecraftDataRegistry = ReturnType<typeof MinecraftData>
 export type RegistryItem = MinecraftDataRegistry['items'][number]

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,31 +1,112 @@
-export declare class Recipe {
-    constructor(recipeEnumItem: object);
+import type MinecraftData = require('minecraft-data')
 
-    result: RecipeItem;
-    inShape: Array<Array<RecipeItem>>;
-    outShape: Array<Array<RecipeItem>>;
-    ingredients: Array<RecipeItem>;
-    delta: Array<RecipeItem>;
-    requiresTable: boolean;
+export type MinecraftDataRegistry = ReturnType<typeof MinecraftData>
+export type RegistryItem = MinecraftDataRegistry['items'][number]
+export type JavaDataRecipe = MinecraftDataRegistry['recipes'][number][number]
+export type JavaDataRecipeItem = JavaDataRecipe['result']
 
-    static find(itemType: number, metadata: number | null): Array<Recipe>;
+export type BedrockRecipeType = string
+
+export type BedrockDataRecipeItem = Partial<Pick<RegistryItem, 'id' | 'name'>> & {
+    metadata?: number | null;
+    count?: number;
 }
-export declare class RecipeItem {
-    constructor(id: number, metadata: number | null, count: number);
 
-    id: number;
+export interface BedrockDataRecipe {
+    name: string | null;
+    type: BedrockRecipeType;
+    ingredients: [BedrockDataRecipeItem, ...BedrockDataRecipeItem[]];
+    input?: number[][];
+    output: [BedrockDataRecipeItem, ...BedrockDataRecipeItem[]];
+    priority?: number;
+}
+
+export type JavaRegistry = Omit<MinecraftDataRegistry, 'type' | 'recipes'> & {
+    type?: Extract<MinecraftDataRegistry['type'], 'pc'>;
+    recipes: Record<number, JavaDataRecipe[]>;
+}
+
+export type BedrockRegistry = Omit<MinecraftDataRegistry, 'type' | 'recipes'> & {
+    type: Extract<MinecraftDataRegistry['type'], 'bedrock'>;
+    recipes: Record<number, BedrockDataRecipe>;
+}
+
+export type RecipeRegistry = JavaRegistry | BedrockRegistry | MinecraftDataRegistry
+export type RecipeEdition = 'java' | 'bedrock'
+export type RecipeItemEnum = JavaDataRecipeItem | BedrockDataRecipeItem | null
+
+export declare class RecipeItem {
+    constructor(id: RegistryItem['id'], metadata: number | null, count: number, name?: RegistryItem['name']);
+
+    id: RegistryItem['id'];
     metadata: number | null;
     count: number;
+    name?: RegistryItem['name'];
 
-    static fromEnum(itemFromRecipeEnum: object): RecipeItem;
+    static fromEnum(itemFromRecipeEnum: RecipeItemEnum): RecipeItem;
     static clone(recipeItem: RecipeItem): RecipeItem;
 }
-type RecipeConstructor = typeof Recipe;
-type RecipeItemConstructor = typeof RecipeItem;
-declare interface RecipeClasses {
-    Recipe: RecipeConstructor;
-    RecipeItem: RecipeItemConstructor;
-}
-declare function loader(mcVersion: string): RecipeClasses;
-export default loader;
 
+export interface BaseRecipe {
+    edition: RecipeEdition;
+    type: BedrockRecipeType | null;
+    name: string | null;
+    result: RecipeItem;
+    results: Array<RecipeItem>;
+    inShape: Array<Array<RecipeItem>> | null;
+    outShape: Array<Array<RecipeItem>> | null;
+    ingredients: Array<RecipeItem> | null;
+    delta: Array<RecipeItem>;
+    requiresTable: boolean;
+}
+
+export interface JavaRecipe extends BaseRecipe {
+    edition: 'java';
+    type: null;
+    name: null;
+}
+
+export interface BedrockRecipe extends BaseRecipe {
+    edition: 'bedrock';
+    type: BedrockRecipeType | null;
+    name: string | null;
+}
+
+export type Recipe = JavaRecipe | BedrockRecipe
+
+export interface RecipeConstructor<TRecipe extends Recipe = Recipe> {
+    new (recipeEnumItem: JavaDataRecipe | BedrockDataRecipe): TRecipe;
+    find(itemType: RegistryItem['id'] | RegistryItem['name'], metadata?: number | null): Array<TRecipe>;
+}
+
+export interface JavaRecipeConstructor extends RecipeConstructor<JavaRecipe> {
+    new (recipeEnumItem: JavaDataRecipe): JavaRecipe;
+    find(itemType: RegistryItem['id'], metadata?: number | null): Array<JavaRecipe>;
+}
+
+export interface BedrockRecipeConstructor extends RecipeConstructor<BedrockRecipe> {
+    new (recipeEnumItem: BedrockDataRecipe): BedrockRecipe;
+    find(itemType: RegistryItem['id'] | RegistryItem['name'], metadata?: number | null): Array<BedrockRecipe>;
+}
+
+export interface RecipeClasses<TRecipe extends Recipe = Recipe> {
+    Recipe: RecipeConstructor<TRecipe>;
+    RecipeItem: typeof RecipeItem;
+}
+
+export interface JavaRecipeClasses extends RecipeClasses<JavaRecipe> {
+    Recipe: JavaRecipeConstructor;
+}
+
+export interface BedrockRecipeClasses extends RecipeClasses<BedrockRecipe> {
+    Recipe: BedrockRecipeConstructor;
+}
+
+declare function loader(mcVersion: `bedrock_${string}`): BedrockRecipeClasses;
+declare function loader(mcVersion: `${number}.${number}` | `${number}.${number}.${number}`): JavaRecipeClasses;
+declare function loader(mcVersion: string): RecipeClasses;
+declare function loader(registry: BedrockRegistry): BedrockRecipeClasses;
+declare function loader(registry: JavaRegistry): JavaRecipeClasses;
+declare function loader(registry: RecipeRegistry): RecipeClasses;
+
+export default loader;

--- a/lib/matching.js
+++ b/lib/matching.js
@@ -1,0 +1,45 @@
+const RecipeItem = require('./recipe_item')
+
+module.exports = function createMatcher (context, normalizer) {
+  return {
+    recipeMatches,
+    resolveFindItem
+  }
+
+  function resolveFindItem (itemType, metadata) {
+    if (typeof itemType === 'string') {
+      const name = normalizer.stripNamespace(itemType)
+      const itemData = normalizer.findItemDataByName(name)
+      const item = new RecipeItem(itemData ? itemData.id : undefined, metadata == null && itemData ? itemData.metadata : metadata, 1, name)
+      item.byName = true
+      return item
+    }
+    const itemData = context.items[itemType]
+    return new RecipeItem(itemType, metadata == null && itemData ? itemData.metadata : metadata, 1)
+  }
+
+  function recipeMatches (recipeEnumItem, findItem) {
+    const results = recipeEnumItem.output || (recipeEnumItem.result ? [recipeEnumItem.result] : [])
+    return results.some(function (result) {
+      return itemMatches(normalizer.reformatItem(result), findItem)
+    })
+  }
+
+  function itemMatches (recipeItem, findItem) {
+    if (findItem.byName && recipeItem.name != null && normalizer.stripNamespace(recipeItem.name) !== normalizer.stripNamespace(findItem.name) && !variationMatches(recipeItem, findItem)) {
+      return false
+    }
+    if (findItem.id != null && recipeItem.id !== findItem.id && !variationMatches(recipeItem, findItem)) {
+      return false
+    }
+    return findItem.metadata == null || recipeItem.metadata == null || recipeItem.metadata === findItem.metadata
+  }
+
+  function variationMatches (recipeItem, findItem) {
+    const itemData = context.items[recipeItem.id]
+    if (!itemData || !itemData.variations) return false
+    return itemData.variations.some(function (variation) {
+      return variation.id === findItem.id && (recipeItem.metadata == null || recipeItem.metadata === variation.metadata)
+    })
+  }
+}

--- a/lib/matching.js
+++ b/lib/matching.js
@@ -21,7 +21,8 @@ module.exports = function createMatcher (context, normalizer) {
   function recipeMatches (recipeEnumItem, findItem) {
     const results = recipeEnumItem.output || (recipeEnumItem.result ? [recipeEnumItem.result] : [])
     return results.some(function (result) {
-      return itemMatches(normalizer.reformatItem(result), findItem)
+      return itemMatches(normalizer.reformatRecipeOutput(recipeEnumItem, result), findItem) ||
+        itemMatches(normalizer.reformatItem(result), findItem)
     })
   }
 

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -7,6 +7,8 @@ module.exports = function createNormalizer (context) {
     reformatBedrockShape,
     reformatIngredients,
     reformatItem,
+    reformatRecipeInput,
+    reformatRecipeOutput,
     reformatResults,
     reformatShape,
     stripNamespace
@@ -42,18 +44,20 @@ module.exports = function createNormalizer (context) {
     return out
   }
 
-  function reformatIngredients (ingredients) {
+  function reformatIngredients (ingredients, recipeEnumItem) {
     const out = new Array(ingredients.length)
     for (let i = 0; i < out.length; ++i) {
-      const item = reformatItem(ingredients[i])
+      const item = recipeEnumItem ? reformatRecipeInput(recipeEnumItem, ingredients[i]) : reformatItem(ingredients[i])
       item.count = -1
       out[i] = item
     }
     return out
   }
 
-  function reformatBedrockShape (input, ingredients) {
-    const indexedIngredients = (ingredients || []).map(reformatItem)
+  function reformatBedrockShape (input, ingredients, recipeEnumItem) {
+    const indexedIngredients = (ingredients || []).map(function (ingredient) {
+      return recipeEnumItem ? reformatRecipeInput(recipeEnumItem, ingredient) : reformatItem(ingredient)
+    })
     const out = new Array(input.length)
     let x, y, row, outRow, ingredient
     for (y = 0; y < input.length; ++y) {
@@ -70,7 +74,9 @@ module.exports = function createNormalizer (context) {
   function reformatResults (recipeEnumItem) {
     const results = recipeEnumItem.output || (recipeEnumItem.result ? [recipeEnumItem.result] : null)
     if (!results) return null
-    return results.map(reformatItem)
+    return results.map(function (result) {
+      return reformatRecipeOutput(recipeEnumItem, result)
+    })
   }
 
   function getPrimaryResult (recipeEnumItem) {
@@ -79,6 +85,73 @@ module.exports = function createNormalizer (context) {
 
   function reformatItem (item) {
     return normalizeMetadata(resolveNamedItem(RecipeItem.fromEnum(item)))
+  }
+
+  function reformatRecipeInput (recipeEnumItem, item) {
+    return normalizeMetadata(resolveNamedItem(resolveBedrockRecipeInput(recipeEnumItem, RecipeItem.fromEnum(item))))
+  }
+
+  function reformatRecipeOutput (recipeEnumItem, item) {
+    return normalizeMetadata(resolveNamedItem(resolveBedrockRecipeOutput(recipeEnumItem, RecipeItem.fromEnum(item))))
+  }
+
+  function resolveBedrockRecipeOutput (recipeEnumItem, item) {
+    if (!context.isBedrock || !recipeEnumItem || !recipeEnumItem.name || !item || item.name == null) return item
+
+    const concreteName = findConcreteResultName(recipeEnumItem)
+    const itemData = findItemDataByName(concreteName)
+    if (!itemData || stripNamespace(item.name) === concreteName || !isLegacyGenericItem(item.name)) return item
+
+    item.name = concreteName
+    item.id = itemData.id
+    item.metadata = itemData.metadata == null ? null : itemData.metadata
+    return item
+  }
+
+  function resolveBedrockRecipeInput (recipeEnumItem, item) {
+    if (!context.isBedrock || !recipeEnumItem || !recipeEnumItem.name || !item || item.name == null) return item
+
+    const concreteName = findConcreteIngredientName(recipeEnumItem, item)
+    const itemData = findItemDataByName(concreteName)
+    if (!itemData || stripNamespace(item.name) === concreteName) return item
+
+    item.name = concreteName
+    item.id = itemData.id
+    item.metadata = itemData.metadata == null ? null : itemData.metadata
+    return item
+  }
+
+  function findConcreteResultName (recipeEnumItem) {
+    return stripRecipeVariant(stripNamespace(recipeEnumItem.name))
+  }
+
+  function findConcreteIngredientName (recipeEnumItem, item) {
+    const recipeName = stripNamespace(recipeEnumItem.name)
+    const inputName = stripNamespace(item.name)
+    const fromIndex = recipeName.indexOf('_from_')
+    const resultName = fromIndex === -1 ? recipeName : recipeName.slice(0, fromIndex)
+    const fromName = fromIndex === -1 ? inputName : recipeName.slice(fromIndex + 6)
+
+    const directName = stripRecipeVariant(fromName)
+    if (fromIndex !== -1 && findItemDataByName(directName)) return directName
+
+    const resultParts = resultName.split('_')
+    for (let i = resultParts.length - 1; i > 0; --i) {
+      const candidate = resultParts.slice(0, i).concat(fromName.split('_')).join('_')
+      if (findItemDataByName(candidate)) return candidate
+    }
+
+    return inputName
+  }
+
+  function isLegacyGenericItem (name) {
+    const itemData = findItemDataByName(stripNamespace(name))
+    return itemData && itemData.stackSize === 1
+  }
+
+  function stripRecipeVariant (name) {
+    const suffixIndex = name.indexOf('_from_')
+    return suffixIndex === -1 ? name : name.slice(0, suffixIndex)
   }
 
   function resolveNamedItem (item) {

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -1,0 +1,108 @@
+const RecipeItem = require('./recipe_item')
+
+module.exports = function createNormalizer (context) {
+  return {
+    findItemDataByName,
+    getPrimaryResult,
+    reformatBedrockShape,
+    reformatIngredients,
+    reformatItem,
+    reformatResults,
+    reformatShape,
+    stripNamespace
+  }
+
+  function normalizeMetadata (recipeItem) {
+    if (recipeItem.metadata == null || recipeItem.id === -1) return recipeItem
+    // Vanilla Minecraft uses 32767 as the wildcard damage value in recipes.
+    if (recipeItem.metadata >= 32767) {
+      recipeItem.metadata = null
+      return recipeItem
+    }
+    // Some recipe data uses block metadata that is not valid for the item form.
+    const itemData = context.items[recipeItem.id]
+    if (itemData && itemData.variations) {
+      const validMetadata = itemData.variations.map(function (v) { return v.metadata })
+      if (itemData.metadata != null) validMetadata.push(itemData.metadata)
+      if (validMetadata.indexOf(recipeItem.metadata) === -1) {
+        recipeItem.metadata = null
+      }
+    }
+    return recipeItem
+  }
+
+  function reformatShape (shape) {
+    const out = new Array(shape.length)
+    let x, y, row, outRow
+    for (y = 0; y < shape.length; ++y) {
+      row = shape[y]
+      out[y] = outRow = new Array(row.length)
+      for (x = 0; x < outRow.length; ++x) { outRow[x] = reformatItem(row[x]) }
+    }
+    return out
+  }
+
+  function reformatIngredients (ingredients) {
+    const out = new Array(ingredients.length)
+    for (let i = 0; i < out.length; ++i) {
+      const item = reformatItem(ingredients[i])
+      item.count = -1
+      out[i] = item
+    }
+    return out
+  }
+
+  function reformatBedrockShape (input, ingredients) {
+    const indexedIngredients = (ingredients || []).map(reformatItem)
+    const out = new Array(input.length)
+    let x, y, row, outRow, ingredient
+    for (y = 0; y < input.length; ++y) {
+      row = input[y]
+      out[y] = outRow = new Array(row.length)
+      for (x = 0; x < row.length; ++x) {
+        ingredient = indexedIngredients[row[x] - 1]
+        outRow[x] = ingredient ? RecipeItem.clone(ingredient) : RecipeItem.fromEnum(null)
+      }
+    }
+    return out
+  }
+
+  function reformatResults (recipeEnumItem) {
+    const results = recipeEnumItem.output || (recipeEnumItem.result ? [recipeEnumItem.result] : null)
+    if (!results) return null
+    return results.map(reformatItem)
+  }
+
+  function getPrimaryResult (recipeEnumItem) {
+    return recipeEnumItem.result || (recipeEnumItem.output && recipeEnumItem.output[0])
+  }
+
+  function reformatItem (item) {
+    return normalizeMetadata(resolveNamedItem(RecipeItem.fromEnum(item)))
+  }
+
+  function resolveNamedItem (item) {
+    if (item == null || item.name == null || item.id != null) return item
+    const itemData = findItemDataByName(stripNamespace(item.name))
+    if (!itemData) return item
+    item.id = itemData.id
+    if (item.metadata == null && itemData.metadata != null) item.metadata = itemData.metadata
+    return item
+  }
+
+  function stripNamespace (name) {
+    return name.indexOf(':') === -1 ? name : name.split(':').pop()
+  }
+
+  function findItemDataByName (name) {
+    if (context.itemsByName[name]) return context.itemsByName[name]
+    const itemKeys = Object.keys(context.items)
+    for (let i = 0; i < itemKeys.length; ++i) {
+      const itemData = context.items[itemKeys[i]]
+      if (!itemData || !itemData.variations) continue
+      for (let j = 0; j < itemData.variations.length; ++j) {
+        if (itemData.variations[j].name === name) return itemData.variations[j]
+      }
+    }
+  }
+}

--- a/lib/recipe.js
+++ b/lib/recipe.js
@@ -26,11 +26,11 @@ function loader (registry) {
     this.edition = context.edition
     this.type = recipeEnumItem.type || null
     this.name = recipeEnumItem.name || null
-    this.result = normalizer.reformatItem(normalizer.getPrimaryResult(recipeEnumItem))
+    this.result = normalizer.reformatRecipeOutput(recipeEnumItem, normalizer.getPrimaryResult(recipeEnumItem))
     this.results = normalizer.reformatResults(recipeEnumItem)
 
     this.inShape = recipeEnumItem.input
-      ? normalizer.reformatBedrockShape(recipeEnumItem.input, recipeEnumItem.ingredients)
+      ? normalizer.reformatBedrockShape(recipeEnumItem.input, recipeEnumItem.ingredients, recipeEnumItem)
       : recipeEnumItem.inShape
         ? normalizer.reformatShape(recipeEnumItem.inShape)
         : null
@@ -38,7 +38,7 @@ function loader (registry) {
       ? normalizer.reformatShape(recipeEnumItem.outShape)
       : null
     this.ingredients = !recipeEnumItem.input && recipeEnumItem.ingredients
-      ? normalizer.reformatIngredients(recipeEnumItem.ingredients)
+      ? normalizer.reformatIngredients(recipeEnumItem.ingredients, recipeEnumItem)
       : null
     this.delta = computeDelta(this)
     this.requiresTable = computeRequiresTable(this)

--- a/lib/recipe.js
+++ b/lib/recipe.js
@@ -1,66 +1,71 @@
-let recipes
-let items
-let itemsByName
-let recipeList
-let isBedrock
-let edition
 const RecipeItem = require('./recipe_item')
+const createNormalizer = require('./normalize')
+const createMatcher = require('./matching')
 
 module.exports = loader
 
 function loader (registry) {
-  recipes = registry.recipes || {}
-  items = registry.items || {}
-  itemsByName = registry.itemsByName || {}
-  recipeList = Object.keys(recipes).map(function (key) { return recipes[key] })
-  isBedrock = registry.type === 'bedrock' || recipeList.some(function (recipe) {
+  const context = {
+    recipes: registry.recipes || {},
+    items: registry.items || {},
+    itemsByName: registry.itemsByName || {},
+    recipeList: [],
+    isBedrock: false,
+    edition: 'java'
+  }
+  const normalizer = createNormalizer(context)
+  const matcher = createMatcher(context, normalizer)
+
+  context.recipeList = Object.keys(context.recipes).map(function (key) { return context.recipes[key] })
+  context.isBedrock = registry.type === 'bedrock' || context.recipeList.some(function (recipe) {
     return recipe && !Array.isArray(recipe) && Array.isArray(recipe.output)
   })
-  edition = isBedrock ? 'bedrock' : 'java'
-  return Recipe
-}
+  context.edition = context.isBedrock ? 'bedrock' : 'java'
 
-function Recipe (recipeEnumItem) {
-  this.edition = edition
-  this.type = recipeEnumItem.type || null
-  this.name = recipeEnumItem.name || null
-  this.result = reformatItem(getPrimaryResult(recipeEnumItem))
-  this.results = reformatResults(recipeEnumItem)
+  function Recipe (recipeEnumItem) {
+    this.edition = context.edition
+    this.type = recipeEnumItem.type || null
+    this.name = recipeEnumItem.name || null
+    this.result = normalizer.reformatItem(normalizer.getPrimaryResult(recipeEnumItem))
+    this.results = normalizer.reformatResults(recipeEnumItem)
 
-  this.inShape = recipeEnumItem.input
-    ? reformatBedrockShape(recipeEnumItem.input, recipeEnumItem.ingredients)
-    : recipeEnumItem.inShape
-      ? reformatShape(recipeEnumItem.inShape)
+    this.inShape = recipeEnumItem.input
+      ? normalizer.reformatBedrockShape(recipeEnumItem.input, recipeEnumItem.ingredients)
+      : recipeEnumItem.inShape
+        ? normalizer.reformatShape(recipeEnumItem.inShape)
+        : null
+    this.outShape = recipeEnumItem.outShape
+      ? normalizer.reformatShape(recipeEnumItem.outShape)
       : null
-  this.outShape = recipeEnumItem.outShape
-    ? reformatShape(recipeEnumItem.outShape)
-    : null
-  this.ingredients = !recipeEnumItem.input && recipeEnumItem.ingredients
-    ? reformatIngredients(recipeEnumItem.ingredients)
-    : null
-  this.delta = computeDelta(this)
-  this.requiresTable = computeRequiresTable(this)
-}
+    this.ingredients = !recipeEnumItem.input && recipeEnumItem.ingredients
+      ? normalizer.reformatIngredients(recipeEnumItem.ingredients)
+      : null
+    this.delta = computeDelta(this)
+    this.requiresTable = computeRequiresTable(this)
+  }
 
-Recipe.find = function (itemType, metadata) {
-  const item = resolveFindItem(itemType, metadata)
-  const results = []
+  Recipe.find = function (itemType, metadata) {
+    const item = matcher.resolveFindItem(itemType, metadata)
+    const results = []
 
-  if (!isBedrock) {
-    (recipes[item.id] || []).forEach(function (recipeEnumItem) {
-      if (recipeMatches(recipeEnumItem, item)) {
+    if (!context.isBedrock) {
+      (context.recipes[item.id] || []).forEach(function (recipeEnumItem) {
+        if (matcher.recipeMatches(recipeEnumItem, item)) {
+          results.push(new Recipe(recipeEnumItem))
+        }
+      })
+      return results
+    }
+
+    context.recipeList.forEach(function (recipeEnumItem) {
+      if (matcher.recipeMatches(recipeEnumItem, item)) {
         results.push(new Recipe(recipeEnumItem))
       }
     })
     return results
   }
 
-  recipeList.forEach(function (recipeEnumItem) {
-    if (recipeMatches(recipeEnumItem, item)) {
-      results.push(new Recipe(recipeEnumItem))
-    }
-  })
-  return results
+  return Recipe
 }
 
 function computeRequiresTable (recipe) {
@@ -134,138 +139,4 @@ function computeDelta (recipe) {
       add(RecipeItem.clone(results[i]))
     }
   }
-}
-
-function normalizeMetadata (recipeItem) {
-  if (recipeItem.metadata == null || recipeItem.id === -1) return recipeItem
-  // Vanilla Minecraft uses 32767 as the wildcard damage value in recipes
-  if (recipeItem.metadata >= 32767) {
-    recipeItem.metadata = null
-    return recipeItem
-  }
-  // If the item has known variations and the metadata doesn't match any of them,
-  // treat it as a wildcard. This handles cases like minecraft-data using block
-  // metadata (e.g. 12 for all-bark log) in recipes, which doesn't correspond
-  // to any valid item variant (logs as items only have metadata 0-5).
-  const itemData = items[recipeItem.id]
-  if (itemData && itemData.variations) {
-    const validMetadata = itemData.variations.map(function (v) { return v.metadata })
-    if (itemData.metadata != null) validMetadata.push(itemData.metadata)
-    if (validMetadata.indexOf(recipeItem.metadata) === -1) {
-      recipeItem.metadata = null
-    }
-  }
-  return recipeItem
-}
-
-function reformatShape (shape) {
-  const out = new Array(shape.length)
-  let x, y, row, outRow
-  for (y = 0; y < shape.length; ++y) {
-    row = shape[y]
-    out[y] = outRow = new Array(row.length)
-    for (x = 0; x < outRow.length; ++x) { outRow[x] = reformatItem(row[x]) }
-  }
-  return out
-}
-
-function reformatIngredients (ingredients) {
-  const out = new Array(ingredients.length)
-  for (let i = 0; i < out.length; ++i) {
-    const item = reformatItem(ingredients[i])
-    item.count = -1
-    out[i] = item
-  }
-  return out
-}
-
-function reformatBedrockShape (input, ingredients) {
-  const indexedIngredients = (ingredients || []).map(reformatItem)
-  const out = new Array(input.length)
-  let x, y, row, outRow, ingredient
-  for (y = 0; y < input.length; ++y) {
-    row = input[y]
-    out[y] = outRow = new Array(row.length)
-    for (x = 0; x < row.length; ++x) {
-      ingredient = indexedIngredients[row[x] - 1]
-      outRow[x] = ingredient ? RecipeItem.clone(ingredient) : RecipeItem.fromEnum(null)
-    }
-  }
-  return out
-}
-
-function reformatResults (recipeEnumItem) {
-  const results = recipeEnumItem.output || (recipeEnumItem.result ? [recipeEnumItem.result] : null)
-  if (!results) return null
-  return results.map(reformatItem)
-}
-
-function getPrimaryResult (recipeEnumItem) {
-  return recipeEnumItem.result || (recipeEnumItem.output && recipeEnumItem.output[0])
-}
-
-function reformatItem (item) {
-  return normalizeMetadata(resolveNamedItem(RecipeItem.fromEnum(item)))
-}
-
-function resolveNamedItem (item) {
-  if (item == null || item.name == null || item.id != null) return item
-  const itemData = findItemDataByName(stripNamespace(item.name))
-  if (!itemData) return item
-  item.id = itemData.id
-  if (item.metadata == null && itemData.metadata != null) item.metadata = itemData.metadata
-  return item
-}
-
-function resolveFindItem (itemType, metadata) {
-  if (typeof itemType === 'string') {
-    const name = stripNamespace(itemType)
-    const itemData = findItemDataByName(name)
-    const item = new RecipeItem(itemData ? itemData.id : undefined, metadata == null && itemData ? itemData.metadata : metadata, 1, name)
-    item.byName = true
-    return item
-  }
-  const itemData = items[itemType]
-  return new RecipeItem(itemType, metadata == null && itemData ? itemData.metadata : metadata, 1)
-}
-
-function stripNamespace (name) {
-  return name.indexOf(':') === -1 ? name : name.split(':').pop()
-}
-
-function findItemDataByName (name) {
-  if (itemsByName[name]) return itemsByName[name]
-  const itemKeys = Object.keys(items)
-  for (let i = 0; i < itemKeys.length; ++i) {
-    const itemData = items[itemKeys[i]]
-    if (!itemData || !itemData.variations) continue
-    for (let j = 0; j < itemData.variations.length; ++j) {
-      if (itemData.variations[j].name === name) return itemData.variations[j]
-    }
-  }
-}
-
-function recipeMatches (recipeEnumItem, findItem) {
-  const results = recipeEnumItem.output || (recipeEnumItem.result ? [recipeEnumItem.result] : [])
-  return results.some(function (result) {
-    return itemMatches(reformatItem(result), findItem)
-  })
-}
-
-function itemMatches (recipeItem, findItem) {
-  if (findItem.byName && recipeItem.name != null && stripNamespace(recipeItem.name) !== stripNamespace(findItem.name) && !variationMatches(recipeItem, findItem)) {
-    return false
-  }
-  if (findItem.id != null && recipeItem.id !== findItem.id && !variationMatches(recipeItem, findItem)) {
-    return false
-  }
-  return findItem.metadata == null || recipeItem.metadata == null || recipeItem.metadata === findItem.metadata
-}
-
-function variationMatches (recipeItem, findItem) {
-  const itemData = items[recipeItem.id]
-  if (!itemData || !itemData.variations) return false
-  return itemData.variations.some(function (variation) {
-    return variation.id === findItem.id && (recipeItem.metadata == null || recipeItem.metadata === variation.metadata)
-  })
 }

--- a/lib/recipe.js
+++ b/lib/recipe.js
@@ -1,25 +1,41 @@
 let recipes
 let items
+let itemsByName
+let recipeList
+let isBedrock
+let edition
 const RecipeItem = require('./recipe_item')
 
 module.exports = loader
 
 function loader (registry) {
-  recipes = registry.recipes
+  recipes = registry.recipes || {}
   items = registry.items || {}
+  itemsByName = registry.itemsByName || {}
+  recipeList = Object.keys(recipes).map(function (key) { return recipes[key] })
+  isBedrock = registry.type === 'bedrock' || recipeList.some(function (recipe) {
+    return recipe && !Array.isArray(recipe) && Array.isArray(recipe.output)
+  })
+  edition = isBedrock ? 'bedrock' : 'java'
   return Recipe
 }
 
 function Recipe (recipeEnumItem) {
-  this.result = RecipeItem.fromEnum(recipeEnumItem.result)
+  this.edition = edition
+  this.type = recipeEnumItem.type || null
+  this.name = recipeEnumItem.name || null
+  this.result = reformatItem(getPrimaryResult(recipeEnumItem))
+  this.results = reformatResults(recipeEnumItem)
 
-  this.inShape = recipeEnumItem.inShape
-    ? reformatShape(recipeEnumItem.inShape)
-    : null
+  this.inShape = recipeEnumItem.input
+    ? reformatBedrockShape(recipeEnumItem.input, recipeEnumItem.ingredients)
+    : recipeEnumItem.inShape
+      ? reformatShape(recipeEnumItem.inShape)
+      : null
   this.outShape = recipeEnumItem.outShape
     ? reformatShape(recipeEnumItem.outShape)
     : null
-  this.ingredients = recipeEnumItem.ingredients
+  this.ingredients = !recipeEnumItem.input && recipeEnumItem.ingredients
     ? reformatIngredients(recipeEnumItem.ingredients)
     : null
   this.delta = computeDelta(this)
@@ -27,9 +43,20 @@ function Recipe (recipeEnumItem) {
 }
 
 Recipe.find = function (itemType, metadata) {
-  const results = [];
-  (recipes[itemType] || []).forEach(function (recipeEnumItem) {
-    if ((metadata == null || !('meta' in recipeEnumItem.result) || recipeEnumItem.result.metadata === metadata)) {
+  const item = resolveFindItem(itemType, metadata)
+  const results = []
+
+  if (!isBedrock) {
+    (recipes[item.id] || []).forEach(function (recipeEnumItem) {
+      if (recipeMatches(recipeEnumItem, item)) {
+        results.push(new Recipe(recipeEnumItem))
+      }
+    })
+    return results
+  }
+
+  recipeList.forEach(function (recipeEnumItem) {
+    if (recipeMatches(recipeEnumItem, item)) {
       results.push(new Recipe(recipeEnumItem))
     }
   })
@@ -61,8 +88,11 @@ function computeDelta (recipe) {
   if (recipe.inShape) applyShape(recipe.inShape, -1)
   if (recipe.outShape) applyShape(recipe.outShape, 1)
   if (recipe.ingredients) applyIngredients(recipe.ingredients)
-  // add the result
-  add(RecipeItem.clone(recipe.result))
+  if (recipe.results) {
+    applyResults(recipe.results)
+  } else {
+    add(RecipeItem.clone(recipe.result))
+  }
   return delta
 
   // add to delta
@@ -80,7 +110,7 @@ function computeDelta (recipe) {
   function applyShape (shape, direction) {
     let x, y, row
     for (y = 0; y < shape.length; ++y) {
-      row = recipe.inShape[y]
+      row = shape[y]
       for (x = 0; x < row.length; ++x) {
         if (row[x].id !== -1) {
           const item = RecipeItem.clone(row[x])
@@ -95,6 +125,13 @@ function computeDelta (recipe) {
     let i
     for (i = 0; i < ingredients.length; ++i) {
       add(RecipeItem.clone(ingredients[i]))
+    }
+  }
+
+  function applyResults (results) {
+    let i
+    for (i = 0; i < results.length; ++i) {
+      add(RecipeItem.clone(results[i]))
     }
   }
 }
@@ -113,6 +150,7 @@ function normalizeMetadata (recipeItem) {
   const itemData = items[recipeItem.id]
   if (itemData && itemData.variations) {
     const validMetadata = itemData.variations.map(function (v) { return v.metadata })
+    if (itemData.metadata != null) validMetadata.push(itemData.metadata)
     if (validMetadata.indexOf(recipeItem.metadata) === -1) {
       recipeItem.metadata = null
     }
@@ -126,7 +164,7 @@ function reformatShape (shape) {
   for (y = 0; y < shape.length; ++y) {
     row = shape[y]
     out[y] = outRow = new Array(row.length)
-    for (x = 0; x < outRow.length; ++x) { outRow[x] = normalizeMetadata(RecipeItem.fromEnum(row[x])) }
+    for (x = 0; x < outRow.length; ++x) { outRow[x] = reformatItem(row[x]) }
   }
   return out
 }
@@ -134,9 +172,100 @@ function reformatShape (shape) {
 function reformatIngredients (ingredients) {
   const out = new Array(ingredients.length)
   for (let i = 0; i < out.length; ++i) {
-    const item = normalizeMetadata(RecipeItem.fromEnum(ingredients[i]))
+    const item = reformatItem(ingredients[i])
     item.count = -1
     out[i] = item
   }
   return out
+}
+
+function reformatBedrockShape (input, ingredients) {
+  const indexedIngredients = (ingredients || []).map(reformatItem)
+  const out = new Array(input.length)
+  let x, y, row, outRow, ingredient
+  for (y = 0; y < input.length; ++y) {
+    row = input[y]
+    out[y] = outRow = new Array(row.length)
+    for (x = 0; x < row.length; ++x) {
+      ingredient = indexedIngredients[row[x] - 1]
+      outRow[x] = ingredient ? RecipeItem.clone(ingredient) : RecipeItem.fromEnum(null)
+    }
+  }
+  return out
+}
+
+function reformatResults (recipeEnumItem) {
+  const results = recipeEnumItem.output || (recipeEnumItem.result ? [recipeEnumItem.result] : null)
+  if (!results) return null
+  return results.map(reformatItem)
+}
+
+function getPrimaryResult (recipeEnumItem) {
+  return recipeEnumItem.result || (recipeEnumItem.output && recipeEnumItem.output[0])
+}
+
+function reformatItem (item) {
+  return normalizeMetadata(resolveNamedItem(RecipeItem.fromEnum(item)))
+}
+
+function resolveNamedItem (item) {
+  if (item == null || item.name == null || item.id != null) return item
+  const itemData = findItemDataByName(stripNamespace(item.name))
+  if (!itemData) return item
+  item.id = itemData.id
+  if (item.metadata == null && itemData.metadata != null) item.metadata = itemData.metadata
+  return item
+}
+
+function resolveFindItem (itemType, metadata) {
+  if (typeof itemType === 'string') {
+    const name = stripNamespace(itemType)
+    const itemData = findItemDataByName(name)
+    const item = new RecipeItem(itemData ? itemData.id : undefined, metadata == null && itemData ? itemData.metadata : metadata, 1, name)
+    item.byName = true
+    return item
+  }
+  const itemData = items[itemType]
+  return new RecipeItem(itemType, metadata == null && itemData ? itemData.metadata : metadata, 1)
+}
+
+function stripNamespace (name) {
+  return name.indexOf(':') === -1 ? name : name.split(':').pop()
+}
+
+function findItemDataByName (name) {
+  if (itemsByName[name]) return itemsByName[name]
+  const itemKeys = Object.keys(items)
+  for (let i = 0; i < itemKeys.length; ++i) {
+    const itemData = items[itemKeys[i]]
+    if (!itemData || !itemData.variations) continue
+    for (let j = 0; j < itemData.variations.length; ++j) {
+      if (itemData.variations[j].name === name) return itemData.variations[j]
+    }
+  }
+}
+
+function recipeMatches (recipeEnumItem, findItem) {
+  const results = recipeEnumItem.output || (recipeEnumItem.result ? [recipeEnumItem.result] : [])
+  return results.some(function (result) {
+    return itemMatches(reformatItem(result), findItem)
+  })
+}
+
+function itemMatches (recipeItem, findItem) {
+  if (findItem.byName && recipeItem.name != null && stripNamespace(recipeItem.name) !== stripNamespace(findItem.name) && !variationMatches(recipeItem, findItem)) {
+    return false
+  }
+  if (findItem.id != null && recipeItem.id !== findItem.id && !variationMatches(recipeItem, findItem)) {
+    return false
+  }
+  return findItem.metadata == null || recipeItem.metadata == null || recipeItem.metadata === findItem.metadata
+}
+
+function variationMatches (recipeItem, findItem) {
+  const itemData = items[recipeItem.id]
+  if (!itemData || !itemData.variations) return false
+  return itemData.variations.some(function (variation) {
+    return variation.id === findItem.id && (recipeItem.metadata == null || recipeItem.metadata === variation.metadata)
+  })
 }

--- a/lib/recipe_item.js
+++ b/lib/recipe_item.js
@@ -1,24 +1,29 @@
 module.exports = RecipeItem
 
-function RecipeItem (id, metadata, count) {
+function RecipeItem (id, metadata, count, name) {
   this.id = id
   this.metadata = metadata
   this.count = count
+  if (name != null) this.name = name
 }
 
 RecipeItem.fromEnum = function (itemFromRecipeEnum) {
   if (itemFromRecipeEnum === null) { return new RecipeItem(-1, null, 1) } else {
-    switch (typeof itemFromRecipeEnum) {
-      case 'array':
-        return new RecipeItem(itemFromRecipeEnum[0], itemFromRecipeEnum[1], 1)
-      case 'number':
-        return new RecipeItem(itemFromRecipeEnum, null, 1)
-      case 'object':
-        return new RecipeItem(itemFromRecipeEnum.id, itemFromRecipeEnum.metadata == null ? null : itemFromRecipeEnum.metadata, itemFromRecipeEnum.count || 1)
+    if (Array.isArray(itemFromRecipeEnum)) {
+      return new RecipeItem(itemFromRecipeEnum[0], itemFromRecipeEnum[1] == null ? null : itemFromRecipeEnum[1], 1)
+    } else if (typeof itemFromRecipeEnum === 'number') {
+      return new RecipeItem(itemFromRecipeEnum, null, 1)
+    } else if (typeof itemFromRecipeEnum === 'object') {
+      return new RecipeItem(
+        itemFromRecipeEnum.id,
+        itemFromRecipeEnum.metadata == null ? null : itemFromRecipeEnum.metadata,
+        itemFromRecipeEnum.count || 1,
+        itemFromRecipeEnum.name
+      )
     }
   }
 }
 
 RecipeItem.clone = function (recipeItem) {
-  return new RecipeItem(recipeItem.id, recipeItem.metadata, recipeItem.count)
+  return new RecipeItem(recipeItem.id, recipeItem.metadata, recipeItem.count, recipeItem.name)
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "peerDependencies": {
     "prismarine-registry": "^1.4.0"
   },
+  "dependencies": {
+    "minecraft-data": "^3.70.0"
+  },
   "devDependencies": {
     "mocha": "^11.7.5",
     "standard": "^17.0.0"

--- a/test/agnostic.test.js
+++ b/test/agnostic.test.js
@@ -61,6 +61,42 @@ describe('RecipeItem', function () {
 })
 
 describe('Recipe agnostic format', function () {
+  it('should isolate state between loaded registries', function () {
+    const JavaRecipe = recipeLoader({
+      recipes: {
+        1: [{
+          result: { id: 1, count: 1 },
+          ingredients: [2]
+        }]
+      }
+    })
+    const BedrockRecipe = recipeLoader({
+      type: 'bedrock',
+      items: {
+        3: { id: 3, name: 'cake' },
+        4: { id: 4, name: 'sugar' }
+      },
+      itemsByName: {
+        cake: { id: 3, name: 'cake' },
+        sugar: { id: 4, name: 'sugar' }
+      },
+      recipes: {
+        0: {
+          type: 'crafting_table_shapeless',
+          name: 'cake_recipe',
+          ingredients: [{ name: 'sugar', count: 1 }],
+          input: [[1]],
+          output: [{ name: 'cake', count: 1 }]
+        }
+      }
+    })
+
+    assert.strictEqual(JavaRecipe.find(1)[0].edition, 'java')
+    assert.strictEqual(BedrockRecipe.find('cake')[0].edition, 'bedrock')
+    assert.strictEqual(JavaRecipe.find(1)[0].result.id, 1)
+    assert.strictEqual(BedrockRecipe.find('cake')[0].result.id, 3)
+  })
+
   describe('computeDelta mutation', function () {
     it('should not mutate ingredient counts after recipe creation', function () {
       const registry = {

--- a/test/agnostic.test.js
+++ b/test/agnostic.test.js
@@ -33,6 +33,13 @@ describe('RecipeItem', function () {
       assert.strictEqual(item.count, 1)
     })
 
+    it('should handle array input', function () {
+      const item = RecipeItem.fromEnum([5, 2])
+      assert.strictEqual(item.id, 5)
+      assert.strictEqual(item.metadata, 2)
+      assert.strictEqual(item.count, 1)
+    })
+
     it('should handle null input', function () {
       const item = RecipeItem.fromEnum(null)
       assert.strictEqual(item.id, -1)
@@ -44,10 +51,16 @@ describe('RecipeItem', function () {
       const item = RecipeItem.fromEnum({ id: 1, metadata: 2, count: 4 })
       assert.strictEqual(item.count, 4)
     })
+
+    it('should preserve item name when provided', function () {
+      const item = RecipeItem.fromEnum({ name: 'oak_planks', count: 4 })
+      assert.strictEqual(item.name, 'oak_planks')
+      assert.strictEqual(item.count, 4)
+    })
   })
 })
 
-describe('Recipe', function () {
+describe('Recipe agnostic format', function () {
   describe('computeDelta mutation', function () {
     it('should not mutate ingredient counts after recipe creation', function () {
       const registry = {
@@ -61,11 +74,9 @@ describe('Recipe', function () {
       const Recipe = recipeLoader(registry)
       const recipe = Recipe.find(1)[0]
 
-      // Ingredients should have count of -1 (consumed)
       assert.strictEqual(recipe.ingredients[0].count, -1)
       assert.strictEqual(recipe.ingredients[1].count, -1)
 
-      // The delta should also reflect -1 for ingredients
       const ingredientDeltas = recipe.delta.filter(d => d.id === 2 || d.id === 3)
       for (const d of ingredientDeltas) {
         assert.strictEqual(d.count, -1)
@@ -84,12 +95,8 @@ describe('Recipe', function () {
       const Recipe = recipeLoader(registry)
       const recipe = Recipe.find(1)[0]
 
-      // Result count should remain as originally set
       assert.strictEqual(recipe.result.count, 2)
-
-      // Delta for the result should also be 2 (produced)
-      const resultDelta = recipe.delta.find(d => d.id === 1)
-      assert.strictEqual(resultDelta.count, 2)
+      assert.strictEqual(recipe.delta.find(d => d.id === 1).count, 2)
     })
 
     it('should not mutate inShape items after recipe creation', function () {
@@ -104,10 +111,24 @@ describe('Recipe', function () {
       const Recipe = recipeLoader(registry)
       const recipe = Recipe.find(4)[0]
 
-      // inShape items should not have their counts modified by computeDelta
       assert.strictEqual(recipe.inShape[0][0].count, 1)
       assert.strictEqual(recipe.inShape[0][1].count, 1)
       assert.strictEqual(recipe.inShape[1][0].count, 1)
+    })
+
+    it('should use outShape when applying output shape delta', function () {
+      const registry = {
+        recipes: {
+          1: [{
+            result: { id: 1, count: 1 },
+            outShape: [[2, 2]]
+          }]
+        }
+      }
+      const Recipe = recipeLoader(registry)
+      const recipe = Recipe.find(1)[0]
+
+      assert.strictEqual(recipe.delta.find(d => d.id === 2).count, 2)
     })
   })
 
@@ -126,8 +147,7 @@ describe('Recipe', function () {
       const recipe = Recipe.find(1)[0]
 
       assert.strictEqual(recipe.inShape[0][0].metadata, null)
-      const ingredientDelta = recipe.delta.find(d => d.id === 17)
-      assert.strictEqual(ingredientDelta.metadata, null)
+      assert.strictEqual(recipe.delta.find(d => d.id === 17).metadata, null)
     })
 
     it('should treat metadata as wildcard when it does not match any item variation', function () {
@@ -138,9 +158,7 @@ describe('Recipe', function () {
             name: 'log',
             variations: [
               { metadata: 0, displayName: 'Oak Wood' },
-              { metadata: 1, displayName: 'Spruce Wood' },
-              { metadata: 2, displayName: 'Birch Wood' },
-              { metadata: 3, displayName: 'Jungle Wood' }
+              { metadata: 1, displayName: 'Spruce Wood' }
             ]
           }
         },
@@ -154,10 +172,8 @@ describe('Recipe', function () {
       const Recipe = recipeLoader(registry)
       const recipe = Recipe.find(5)[0]
 
-      // metadata 12 is not a valid item variation for log, so it should be null
       assert.strictEqual(recipe.inShape[0][0].metadata, null)
-      const logDelta = recipe.delta.find(d => d.id === 17)
-      assert.strictEqual(logDelta.metadata, null)
+      assert.strictEqual(recipe.delta.find(d => d.id === 17).metadata, null)
     })
 
     it('should preserve metadata when it matches a valid item variation', function () {
@@ -168,8 +184,7 @@ describe('Recipe', function () {
             name: 'wool',
             variations: [
               { metadata: 0, displayName: 'White Wool' },
-              { metadata: 1, displayName: 'Orange Wool' },
-              { metadata: 2, displayName: 'Magenta Wool' }
+              { metadata: 1, displayName: 'Orange Wool' }
             ]
           }
         },
@@ -183,8 +198,30 @@ describe('Recipe', function () {
       const Recipe = recipeLoader(registry)
       const recipe = Recipe.find(1)[0]
 
-      // metadata 1 is a valid variation for wool, so it should be preserved
       assert.strictEqual(recipe.inShape[0][0].metadata, 1)
+    })
+
+    it('should preserve metadata when it matches the base item metadata', function () {
+      const registry = {
+        items: {
+          1: {
+            id: 1,
+            name: 'bed',
+            metadata: 0,
+            variations: [{ id: 2, name: 'orange_bed', metadata: 1 }]
+          }
+        },
+        recipes: {
+          1: [{
+            result: { id: 1, count: 1 },
+            inShape: [[{ id: 1, metadata: 0 }]]
+          }]
+        }
+      }
+      const Recipe = recipeLoader(registry)
+      const recipe = Recipe.find(1)[0]
+
+      assert.strictEqual(recipe.inShape[0][0].metadata, 0)
     })
 
     it('should normalize metadata in ingredients too', function () {
@@ -227,7 +264,6 @@ describe('Recipe', function () {
       const Recipe = recipeLoader(registry)
       const recipe = Recipe.find(1)[0]
 
-      // No variations data, so metadata should be preserved as-is
       assert.strictEqual(recipe.inShape[0][0].metadata, 5)
     })
   })

--- a/test/bedrock.test.js
+++ b/test/bedrock.test.js
@@ -1,0 +1,121 @@
+/* eslint-env mocha */
+const assert = require('assert')
+const recipeLoader = require('../lib/recipe')
+
+describe('Bedrock recipes', function () {
+  it('should resolve named inputs and outputs from the registry', function () {
+    const registry = {
+      type: 'bedrock',
+      items: {
+        1: { id: 1, name: 'planks' },
+        2: { id: 2, name: 'book' },
+        3: { id: 3, name: 'bookshelf' }
+      },
+      itemsByName: {
+        planks: { id: 1, name: 'planks' },
+        book: { id: 2, name: 'book' },
+        bookshelf: { id: 3, name: 'bookshelf' }
+      },
+      recipes: {
+        0: {
+          type: 'crafting_table',
+          name: 'Bookshelf_recipeId',
+          ingredients: [{ name: 'planks', count: 6 }, { name: 'book', count: 3 }],
+          input: [[1, 1, 1], [2, 2, 2], [1, 1, 1]],
+          output: [{ name: 'bookshelf', metadata: 0, count: 1 }]
+        }
+      }
+    }
+    const Recipe = recipeLoader(registry)
+    const recipe = Recipe.find('bookshelf')[0]
+
+    assert.strictEqual(recipe.edition, 'bedrock')
+    assert.strictEqual(recipe.type, 'crafting_table')
+    assert.strictEqual(recipe.name, 'Bookshelf_recipeId')
+    assert.strictEqual(recipe.result.id, 3)
+    assert.strictEqual(recipe.result.name, 'bookshelf')
+    assert.strictEqual(recipe.inShape[0][0].id, 1)
+    assert.strictEqual(recipe.inShape[1][0].id, 2)
+    assert.strictEqual(recipe.requiresTable, true)
+    assert.strictEqual(recipe.delta.find(d => d.id === 1).count, -6)
+    assert.strictEqual(recipe.delta.find(d => d.id === 2).count, -3)
+    assert.strictEqual(recipe.delta.find(d => d.id === 3).count, 1)
+  })
+
+  it('should include all outputs in results and delta', function () {
+    const registry = {
+      type: 'bedrock',
+      items: {
+        1: { id: 1, name: 'milk_bucket' },
+        2: { id: 2, name: 'sugar' },
+        3: { id: 3, name: 'egg' },
+        4: { id: 4, name: 'wheat' },
+        5: { id: 5, name: 'cake' },
+        6: { id: 6, name: 'bucket' }
+      },
+      itemsByName: {
+        milk_bucket: { id: 1, name: 'milk_bucket' },
+        sugar: { id: 2, name: 'sugar' },
+        egg: { id: 3, name: 'egg' },
+        wheat: { id: 4, name: 'wheat' },
+        cake: { id: 5, name: 'cake' },
+        bucket: { id: 6, name: 'bucket' }
+      },
+      recipes: {
+        0: {
+          type: 'crafting_table',
+          name: 'minecraft:cake',
+          ingredients: [
+            { name: 'milk_bucket', count: 3 },
+            { name: 'sugar', count: 2 },
+            { name: 'egg', count: 1 },
+            { name: 'wheat', count: 3 }
+          ],
+          input: [[1, 1, 1], [2, 3, 2], [4, 4, 4]],
+          output: [{ name: 'cake', count: 1 }, { name: 'bucket', count: 3 }]
+        }
+      }
+    }
+    const Recipe = recipeLoader(registry)
+    const byName = Recipe.find('cake')[0]
+    const byId = Recipe.find(5)[0]
+
+    assert.strictEqual(byName.results.length, 2)
+    assert.strictEqual(byName.results[1].id, 6)
+    assert.strictEqual(byName.delta.find(d => d.id === 6).count, 3)
+    assert.strictEqual(byId.result.name, 'cake')
+    assert.strictEqual(Recipe.find('bucket').length, 1)
+  })
+
+  it('should match variation ids to base recipe metadata', function () {
+    const registry = {
+      type: 'bedrock',
+      items: {
+        1: {
+          id: 1,
+          name: 'bed',
+          metadata: 0,
+          variations: [{ id: 2, name: 'black_bed', metadata: 15 }]
+        },
+        2: { id: 2, name: 'black_bed', metadata: 15 }
+      },
+      itemsByName: {
+        bed: { id: 1, name: 'bed', metadata: 0 },
+        black_bed: { id: 2, name: 'black_bed', metadata: 15 }
+      },
+      recipes: {
+        0: {
+          type: 'crafting_table_shapeless',
+          name: 'bed_dye_0_15',
+          ingredients: [{ name: 'bed', count: 1 }],
+          input: [[1]],
+          output: [{ name: 'bed', metadata: 15, count: 1 }]
+        }
+      }
+    }
+    const Recipe = recipeLoader(registry)
+
+    assert.strictEqual(Recipe.find(2).length, 1)
+    assert.strictEqual(Recipe.find('black_bed').length, 1)
+  })
+})

--- a/test/bedrock.test.js
+++ b/test/bedrock.test.js
@@ -118,4 +118,47 @@ describe('Bedrock recipes', function () {
     assert.strictEqual(Recipe.find(2).length, 1)
     assert.strictEqual(Recipe.find('black_bed').length, 1)
   })
+
+  it('should resolve legacy generic planks outputs to concrete Bedrock item names', function () {
+    const registry = {
+      type: 'bedrock',
+      items: {
+        1: { id: 1, name: 'planks', stackSize: 1 },
+        2: { id: 2, name: 'oak_planks' },
+        3: { id: 3, name: 'oak_log' },
+        4: { id: 4, name: 'log' }
+      },
+      itemsByName: {
+        planks: { id: 1, name: 'planks', stackSize: 1 },
+        oak_planks: { id: 2, name: 'oak_planks' },
+        oak_log: { id: 3, name: 'oak_log' },
+        log: { id: 4, name: 'log' }
+      },
+      recipes: {
+        0: {
+          type: 'crafting_table',
+          name: 'minecraft:oak_planks',
+          ingredients: [{ name: 'log', count: 1 }],
+          input: [[1]],
+          output: [{ name: 'planks', metadata: 0, count: 4 }]
+        }
+      }
+    }
+    const Recipe = recipeLoader(registry)
+
+    const byConcreteName = Recipe.find('oak_planks')
+    const byConcreteId = Recipe.find(2)
+    const byGenericName = Recipe.find('planks')
+
+    assert.strictEqual(byConcreteName.length, 1)
+    assert.strictEqual(byConcreteId.length, 1)
+    assert.strictEqual(byGenericName.length, 1)
+    assert.strictEqual(byConcreteName[0].result.id, 2)
+    assert.strictEqual(byConcreteName[0].result.name, 'oak_planks')
+    assert.strictEqual(byConcreteName[0].result.metadata, null)
+    assert.strictEqual(byConcreteName[0].inShape[0][0].id, 3)
+    assert.strictEqual(byConcreteName[0].inShape[0][0].name, 'oak_log')
+    assert.strictEqual(byConcreteName[0].delta.find(d => d.id === 3).count, -1)
+    assert.strictEqual(byConcreteName[0].delta.find(d => d.id === 2).count, 4)
+  })
 })

--- a/test/java.test.js
+++ b/test/java.test.js
@@ -1,0 +1,41 @@
+/* eslint-env mocha */
+const assert = require('assert')
+const recipeLoader = require('../lib/recipe')
+
+describe('Java recipes', function () {
+  it('should expose java edition recipes in the normalized format', function () {
+    const registry = {
+      recipes: {
+        5: [{
+          result: { id: 5, metadata: 0, count: 4 },
+          inShape: [[17]]
+        }]
+      }
+    }
+    const Recipe = recipeLoader(registry)
+    const recipe = Recipe.find(5)[0]
+
+    assert.strictEqual(recipe.edition, 'java')
+    assert.strictEqual(recipe.type, null)
+    assert.strictEqual(recipe.name, null)
+    assert.strictEqual(recipe.result.id, 5)
+    assert.strictEqual(recipe.results.length, 1)
+    assert.strictEqual(recipe.results[0].id, 5)
+  })
+
+  it('should filter recipes by result metadata', function () {
+    const registry = {
+      recipes: {
+        5: [
+          { result: { id: 5, metadata: 0, count: 4 }, inShape: [[17]] },
+          { result: { id: 5, metadata: 1, count: 4 }, inShape: [[17]] }
+        ]
+      }
+    }
+    const Recipe = recipeLoader(registry)
+    const recipes = Recipe.find(5, 1)
+
+    assert.strictEqual(recipes.length, 1)
+    assert.strictEqual(recipes[0].result.metadata, 1)
+  })
+})

--- a/test/live.test.js
+++ b/test/live.test.js
@@ -1,0 +1,73 @@
+/* eslint-env mocha */
+const assert = require('assert')
+const registry = require('prismarine-registry')
+const recipeLoader = require('../')
+
+describe('Live registry recipes', function () {
+  const javaVersions = ['1.8', '1.12.2', '1.16.5', '1.20.4', '1.21.4']
+  const bedrockVersions = ['bedrock_1.20.0', 'bedrock_1.21.0', 'bedrock_1.21.80']
+
+  for (const version of javaVersions) {
+    it(`should load Java recipes for ${version}`, function () {
+      const data = registry(version)
+      const Recipe = recipeLoader(data).Recipe
+      const recipeId = firstRecipeId(data)
+      const recipes = Recipe.find(recipeId)
+
+      assert.ok(recipes.length > 0)
+      assert.strictEqual(recipes[0].edition, 'java')
+      assert.strictEqual(recipes[0].type, null)
+      assert.strictEqual(recipes[0].name, null)
+      assert.strictEqual(recipes[0].result.id, recipeId)
+      assert.ok(recipes[0].results.length > 0)
+      assert.ok(recipes[0].delta.length > 0)
+    })
+  }
+
+  for (const version of bedrockVersions) {
+    it(`should load Bedrock recipes for ${version}`, function () {
+      const data = registry(version)
+      const Recipe = recipeLoader(data).Recipe
+      const recipeData = firstRecipeWithKnownOutput(data)
+      const output = recipeData.output[0]
+      const recipesByName = Recipe.find(output.name)
+      const recipesById = Recipe.find(data.itemsByName[output.name].id, output.metadata)
+
+      assert.ok(recipesByName.length > 0)
+      assert.ok(recipesById.length > 0)
+      assert.strictEqual(recipesByName[0].edition, 'bedrock')
+      assert.strictEqual(typeof recipesByName[0].type, 'string')
+      assert.ok(recipesByName[0].name == null || typeof recipesByName[0].name === 'string')
+      assert.strictEqual(recipesByName[0].result.name, output.name)
+      assert.ok(recipesByName[0].results.length > 0)
+      assert.ok(recipesByName[0].delta.length > 0)
+    })
+  }
+
+  it('should keep live Java and Bedrock loaders isolated', function () {
+    const JavaRecipe = recipeLoader('1.21.4').Recipe
+    const BedrockRecipe = recipeLoader('bedrock_1.21.80').Recipe
+
+    assert.strictEqual(JavaRecipe.find(5)[0].edition, 'java')
+    assert.strictEqual(BedrockRecipe.find('cake')[0].edition, 'bedrock')
+    assert.strictEqual(JavaRecipe.find(5)[0].edition, 'java')
+  })
+})
+
+function firstRecipeId (data) {
+  return Number(Object.keys(data.recipes).find(function (id) {
+    return data.recipes[id] && data.recipes[id].length > 0
+  }))
+}
+
+function firstRecipeWithKnownOutput (data) {
+  return Object.keys(data.recipes)
+    .map(function (id) { return data.recipes[id] })
+    .find(function (recipe) {
+      return recipe &&
+        recipe.output &&
+        recipe.output[0] &&
+        recipe.output[0].name &&
+        data.itemsByName[recipe.output[0].name]
+    })
+}


### PR DESCRIPTION
This code is meant to add first-class support for both Java and Bedrock recipes. Notably, it condenses both to a generic format that can be used in the same way as upstream's implementation.

